### PR TITLE
Add a metric to show task notification delay.

### DIFF
--- a/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
+++ b/core/src/main/java/com/netflix/conductor/metrics/Monitors.java
@@ -593,4 +593,18 @@ public class Monitors {
     public static void recordTaskExecLogSize(int val) {
         gauge(classQualifier, "task_exec_log_size", val);
     }
+
+    public static void recordTaskNotificationDelay(
+            String workflowId, String taskType, String taskId, long delayMs) {
+        gauge(
+                classQualifier,
+                "task_notification_delay_ms",
+                delayMs,
+                "workflowId",
+                workflowId,
+                "taskType",
+                taskType,
+                "taskId",
+                taskId);
+    }
 }

--- a/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisher.java
+++ b/task-status-listener/src/main/java/com/netflix/conductor/contribs/listener/TaskStatusPublisher.java
@@ -25,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import com.netflix.conductor.core.dal.ExecutionDAOFacade;
 import com.netflix.conductor.core.listener.TaskStatusListener;
+import com.netflix.conductor.metrics.Monitors;
 import com.netflix.conductor.model.TaskModel;
 
 @Singleton
@@ -221,6 +222,9 @@ public class TaskStatusPublisher implements TaskStatusListener {
 
     private void publishTaskNotification(TaskNotification taskNotification) throws IOException {
         String jsonTask = taskNotification.toJsonStringWithInputOutput();
+
+        // Measure the time for task notification
+        long startTime = System.currentTimeMillis();
         rcm.postNotification(
                 RestClientManager.NotificationType.TASK,
                 jsonTask,
@@ -228,5 +232,13 @@ public class TaskStatusPublisher implements TaskStatusListener {
                 taskNotification.getAccountMoId(),
                 taskNotification.getTaskId(),
                 null);
+        long delayMs = System.currentTimeMillis() - startTime;
+
+        // Record task notification delay metric when notification is successfully sent
+        Monitors.recordTaskNotificationDelay(
+                taskNotification.getWorkflowId(),
+                taskNotification.getTaskType(),
+                taskNotification.getTaskId(),
+                delayMs);
     }
 }


### PR DESCRIPTION
Changes in this PR
----
This PR introduces a new metric, task_notification_delay_ms, which measures the time (in milliseconds) between when a task notification is sent and its corresponding acknowledgment is received. This metric provides crucial insight into the latency and responsiveness of task processing.

