### PR TITLE
ISICO-16158: Update the Java version to 21 to match the upstream branch

### DIFF
--- a/.github/workflows/ciscom31_publish_jar.yml
+++ b/.github/workflows/ciscom31_publish_jar.yml
@@ -21,11 +21,11 @@ jobs:
           fetch-depth: 0
       - name: Gradle wrapper validation
         uses: gradle/wrapper-validation-action@v1
-      - name: Set up Zulu JDK 17
+      - name: Set up Zulu JDK 21
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Pull Request type
----
- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] WHOSUSING.md
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Jdk version changed to in ciscom31_publish_jar.yml
----

Latest PR building failing since ciscom31_publish_jar.yml file is referring to Jdk 17. The upstream has transitioned to JDK 21, this needs to be fixed in our custom build file.

Issue #

Alternatives considered
----

_Describe alternative implementation you have considered_
